### PR TITLE
Feat: 지도페이지 검색기능 구현

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -6,7 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />
-    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_KEY%"></script>
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_KEY%&libraries=services"
+    ></script>
     <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> -->
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/client/src/pages/Map.tsx
+++ b/client/src/pages/Map.tsx
@@ -7,8 +7,12 @@ declare global {
     kakao: any;
   }
 }
-const MapComponent: React.FC = () => {
+interface SearchProps {
+  Place: string;
+}
+const MapComponent: React.FC<SearchProps> = ({ Place }) => {
   useEffect(() => {
+    const infowindow = new window.kakao.maps.InfoWindow({ zIndex: 1 });
     const container = document.getElementById("map");
     const options = {
       center: new window.kakao.maps.LatLng(33.450701, 126.570667),
@@ -16,19 +20,43 @@ const MapComponent: React.FC = () => {
     };
 
     const map = new window.kakao.maps.Map(container, options);
-  }, []);
+    const ps = new window.kakao.maps.services.Places();
+
+    ps.keywordSearch(Place, placesSearchCB);
+
+    function placesSearchCB(data: any, status: any) {
+      if (status === window.kakao.maps.services.Status.OK) {
+        const bounds = new window.kakao.maps.LatLngBounds();
+
+        for (let i = 0; i < data.length; i++) {
+          displayMarker(data[i]);
+          bounds.extend(new window.kakao.maps.LatLng(data[i].y, data[i].x));
+        }
+        map.setBounds(bounds);
+      }
+    }
+
+    function displayMarker(place: any) {
+      const marker = new window.kakao.maps.Marker({
+        map: map,
+        position: new window.kakao.maps.LatLng(place.y, place.x),
+      });
+      window.kakao.maps.event.addListener(marker, "click", function () {
+        infowindow.setContent('<div style="padding:5px;font-size:12px;">' + place.place_name + "</div>");
+        infowindow.open(map, marker);
+      });
+    }
+  }, [Place]);
 
   return (
     <div>
       <div id="map" style={{ width: "700px", height: "50vh" }}></div>
       <script
         type="text/javascript"
-        src="//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.REACT_APP_KAKAO_MAP_KEY}"
+        src="//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.REACT_APP_KAKAO_MAP_KEY}&libraries=services"
       ></script>
     </div>
   );
 };
 
 export default MapComponent;
-
-//0513 23:35pm

--- a/client/src/pages/Place.tsx
+++ b/client/src/pages/Place.tsx
@@ -1,6 +1,6 @@
 //지도페이지
 
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import MapComponent from "./Map";
 
@@ -54,18 +54,32 @@ const MapBottomStyled = styled.div`
 `;
 
 const Place = () => {
+  const [inputText, setInputText] = useState("");
+  const [searchPlace, setSearchPlace] = useState("");
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // console.log(e.target.value);
+    setInputText(e.target.value);
+  };
+  const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setSearchPlace(inputText);
+    // console.log(inputText);
+    setInputText("");
+  };
+
   return (
     <>
       <TotalStyled>
         <PlaceContainer>
           <SearchPartStyled>
-            <input type="text" placeholder="매장을 검색하세요"></input>
-            <button>조회</button>
+            <input type="text" placeholder="매장을 검색하세요" onChange={onChange} value={inputText}></input>
+            <button onClick={handleSubmit}>조회</button>
           </SearchPartStyled>
           <MapBodyStyled>
             <MapPartStyled>
               지도부분
-              <MapComponent />
+              <MapComponent Place={searchPlace} />
             </MapPartStyled>
             <ListPartStyled>리스트부분</ListPartStyled>
           </MapBodyStyled>


### PR DESCRIPTION
### Branch
`fe-feat-map-map` -> `fe`

### 변경 사항
-  카카오지도 이용해서 검색기능 구현

### 유의 사항
- 편의점과 주류매장만 연결해서 구현해야함. 아직 미완성
- env 파일에 REACT_APP_KAKAO_MAP_KEY 값 들어가야함.

### 공지 사항
- 깃헙 오류 문제로 브랜치명이 fe-feat-map-map으로 지정된 점 양해 바랍니다 