### PR TITLE
Feat: Oauth 2 인증 로직 및 상태관리 추가 및 기타 분기 변경

### DIFF
--- a/client/src/components/Common/AlertModal.tsx
+++ b/client/src/components/Common/AlertModal.tsx
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 import { AlertProps } from "../../types/Interfaces";
+import { ButtonLight, ButtonDark } from "./Button";
+
 const AlertContainer = styled.div`
   z-index: 1;
   ${({ theme }) => theme.common.flexCenterCol};
@@ -8,27 +10,43 @@ const AlertContainer = styled.div`
   top: 150px;
   background-color: white;
   border: 1px solid gray;
-  border-radius: 5px;
-  box-shadow: rgba(0, 0, 0, 0.25) 0px 20px 20px, rgba(0, 0, 0, 0.12) 0px -12px 30px, rgba(0, 0, 0, 0.12) 0px 4px 6px,
-    rgba(0, 0, 0, 0.17) 0px 1px 1px, rgba(0, 0, 0, 0.09) 0px -2px 3px;
+  border-radius: 2px;
   height: 100px;
   width: 360px;
   padding: 30px;
   .ok {
     padding: 5px 10px;
-    background-color: #1a73e8;
-    border-radius: 5px;
+    background-color: ${({ theme }) => theme.colors.themeColor};
+    border-radius: 2px;
     color: white;
     cursor: pointer;
   }
 `;
-const Alert = ({ text, onClick }: AlertProps) => {
+const Alert = ({ text, onClickOk, onClickCancel }: AlertProps) => {
   return (
     <AlertContainer>
       {text}
-      <div className="ok" onClick={onClick}>
-        확인
-      </div>
+      {onClickCancel ? (
+        <>
+          <ButtonLight
+            width="150px"
+            height="45px"
+            fontSize="18px"
+            borderRadious="2px"
+            border="solid 1px lightgray"
+            onClick={onClickOk}
+          >
+            이전
+          </ButtonLight>
+          <ButtonDark width="150px" height="45px" fontSize="18px" borderRadious="2px" onClick={onClickCancel}>
+            다음
+          </ButtonDark>
+        </>
+      ) : (
+        <ButtonDark width="150px" height="45px" fontSize="18px" borderRadious="2px" onClick={onClickOk}>
+          다음
+        </ButtonDark>
+      )}
     </AlertContainer>
   );
 };

--- a/client/src/pages/Login/FindEmail.tsx
+++ b/client/src/pages/Login/FindEmail.tsx
@@ -72,7 +72,7 @@ const FindEmail = () => {
   };
   return (
     <Container>
-      {showAlert ? <Alert text={alertMessage} onClick={() => setShowAlert(false)} /> : null}
+      {showAlert ? <Alert text={alertMessage} onClickOk={() => setShowAlert(false)} /> : null}
       <ContentsContainer>
         <TopContainer>
           <Title fontSize="28px" fontWeight="500">

--- a/client/src/pages/Login/FindPassword.tsx
+++ b/client/src/pages/Login/FindPassword.tsx
@@ -63,7 +63,7 @@ const FindPassword = () => {
   }, [ok]);
   return (
     <Container>
-      {showAlert ? <Alert text={alertMessage} onClick={() => setShowAlert(false)} /> : null}
+      {showAlert ? <Alert text={alertMessage} onClickOk={() => setShowAlert(false)} /> : null}
       <ContentsContainer>
         <TopContainer>
           <Title fontSize="28px" fontWeight="500">

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -6,7 +6,7 @@ import { TiSocialFacebook } from "react-icons/ti";
 import { FcGoogle } from "react-icons/fc";
 import Alert from "../../components/Common/AlertModal";
 import axios from "axios";
-const url = `${process.env.REACT_APP_API_URL}/`;
+const url = `${process.env.REACT_APP_API_URL}`;
 
 type TypeProps = {
   type: string;
@@ -41,7 +41,7 @@ const Login = () => {
       password,
     };
     axios
-      .post(`${url}auth/login`, body, {
+      .post(`${url}/auth/login`, body, {
         headers: {
           "Content-Type": "application/json",
         },
@@ -70,11 +70,11 @@ const Login = () => {
   };
   const googleOAuthHandler = () => {
     //오어스 구글 인증링크 이동
-    window.location.assign(`${url}oauth2/authorization/google`);
+    window.location.assign(`${url}/oauth2/authorization/google`);
   };
   const facebookOAuthHandler = () => {
     //오어스 페이스북 인증링크로 이동
-    window.location.assign(`${url}oauth2/authorization/facebook`);
+    window.location.assign(`${url}/oauth2/authorization/facebook`);
   };
   const GotoSign = () => {
     // 회원가입 버튼 클릭 시
@@ -82,7 +82,7 @@ const Login = () => {
   };
   return (
     <Container>
-      {showAlert ? <Alert text={alertMessage} onClick={() => setShowAlert(false)} /> : null}
+      {showAlert ? <Alert text={alertMessage} onClickOk={() => setShowAlert(false)} /> : null}
       <ContentsContainer>
         <TopContainer>
           <Title fontSize="28px" fontWeight="500">

--- a/client/src/pages/Mypage/changeinfo.tsx
+++ b/client/src/pages/Mypage/changeinfo.tsx
@@ -5,8 +5,6 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import useAxiosAll from "../../hooks/useAxiosAll";
 import Alert from "../../components/Common/AlertModal";
-import theme from "../../styles/theme";
-
 type TableProsp = {
   setBody: React.Dispatch<React.SetStateAction<Bodytype>>;
   userInfo: Datatype | null;
@@ -322,7 +320,7 @@ const Modal = ({ email }: { email: string }) => {
   return (
     <>
       <ModalContainer>
-        {showAlert ? <Alert text={alertMessage} onClick={isOk ? okGotoMain : () => setShowAlert(false)} /> : null}
+        {showAlert ? <Alert text={alertMessage} onClickOk={isOk ? okGotoMain : () => setShowAlert(false)} /> : null}
         <ModalBtn onClick={openModalHandler}>회원탈퇴</ModalBtn>
         {isOpen ? (
           <ModalBackdrop onClick={openModalHandler}>
@@ -428,7 +426,7 @@ const Changeinfopage = () => {
   return (
     <>
       <TotalStyled>
-        {showAlert ? <Alert text={alertMessage} onClick={isOk ? okGotoMain : () => setShowAlert(false)} /> : null}
+        {showAlert ? <Alert text={alertMessage} onClickOk={isOk ? okGotoMain : () => setShowAlert(false)} /> : null}
         <InfoContainer>
           <p>회원정보수정</p>
           <InfoBodyupStyled>

--- a/client/src/pages/Signup/SignupInput.tsx
+++ b/client/src/pages/Signup/SignupInput.tsx
@@ -7,6 +7,7 @@ import { ChangeEvent } from "react";
 import Alert from "../../components/Common/AlertModal";
 import axios from "axios";
 import useAxiosAll from "../../hooks/useAxiosAll";
+import { useSelector } from "react-redux";
 
 const url = `${process.env.REACT_APP_API_URL}/`;
 
@@ -17,8 +18,11 @@ type TitleProps = {
 type StepProps = {
   type: string;
 };
-
+interface OauthState {
+  oauthSign: boolean;
+}
 const SignupInput = () => {
+  const IsOauth = useSelector((state: OauthState) => state.oauthSign);
   const navigate = useNavigate();
 
   const [name, setName] = useState(""); // 이름 input 상태
@@ -34,7 +38,7 @@ const SignupInput = () => {
   const [showAlert, setShowAlert] = useState(false); // 알림 띄우기 상태
   const [isOk, setIsOk] = useState(false); // 성공 여부 상태 --> 알람 확인의 onClick 이벤트 별도로 주기 위해
   const [doAxios, data, err, ok] = useAxiosAll(); // axios 요청 응답 에러여부 확인
-
+  const [type, setType] = useState<string | null>(null);
   const onName = (e: ChangeEvent<HTMLInputElement>) => {
     // 이름 onChange 핸들러
     setName(e.target.value);
@@ -100,7 +104,7 @@ const SignupInput = () => {
   useEffect(() => {
     if (err) {
       // 에러 발생 시
-      setAlertMessage("자신의 나이 혹은 이메일을 확인해주세요!");
+      setAlertMessage("모든 정보를 기입하였는지와 이메일을 확인해주세요");
       setShowAlert(true);
     }
   }, [err]);
@@ -114,25 +118,36 @@ const SignupInput = () => {
   }, [ok]);
   const onClickSign = () => {
     // 회원가입 버튼 클릭 시
-    if (password !== passwordCheck) {
-      // 비밀번호와 비밀번호 확인 입력이 일치하지 않을 경우
-      setAlertMessage("비밀번호와 비밀번호 확인이 같지 않습니다!");
-    } else if (!(nick && code && name && birth && number)) {
-      // 모든 정보가 입력이 안되었을 경우
-      setAlertMessage("모든 정보가 입력되어야 합니다!");
-    } else {
-      // 요청 body
+    if (type === "oauth") {
       const body = {
         realName: name,
         displayName: nick,
-        email: email,
-        password: password,
         phone: number,
         birthDate: birth,
-        mailKey: code,
       };
-
-      doAxios("post", "/members/signup", body, false); // post 요청으로 바디를 담아 회원가입 요청
+      console.log(body);
+      doAxios("post", "/members/oauth2-signup", body, true);
+    } else {
+      if (password !== passwordCheck) {
+        // 비밀번호와 비밀번호 확인 입력이 일치하지 않을 경우
+        setAlertMessage("비밀번호와 비밀번호 확인이 같지 않습니다!");
+      } else if (!(nick && code && name && birth && number)) {
+        // 모든 정보가 입력이 안되었을 경우
+        setAlertMessage("모든 정보가 입력되어야 합니다!");
+      } else {
+        // 요청 body
+        const body = {
+          realName: name,
+          displayName: nick,
+          email: email,
+          password: password,
+          phone: number,
+          birthDate: birth,
+          mailKey: code,
+        };
+        console.log(body);
+        doAxios("post", "/members/signup", body, false); // post 요청으로 바디를 담아 회원가입 요청
+      }
     }
   };
   const getCode = () => {
@@ -164,112 +179,132 @@ const SignupInput = () => {
     setShowAlert(false);
     navigate("/login");
   };
+  useEffect(() => {
+    const style = localStorage.getItem("oauthSign");
+    if (style === "true") {
+      setType("oauth");
+    } else if (style === "false") {
+      setType("normal");
+    } else {
+      setType(null);
+      setAlertMessage("잘못된 경로로 접근함!");
+      setShowAlert(true);
+    }
+    localStorage.removeItem("oauthSign");
+  }, []);
   return (
     <Container>
-      {showAlert ? <Alert text={alertMessage} onClick={isOk ? okGotoLogin : () => setShowAlert(false)} /> : null}
-      <InputContainer>
-        <TopContainer>
-          <Title fontSize="28px" fontWeight="500">
-            회원가입
-          </Title>
-          <StepContainer>
-            <Step type="off">
-              01<p className="text">약관동의</p>
-            </Step>
-            <MdOutlineKeyboardArrowRight size="22px" color="#A84448" />
-            <Step type="on">
-              02<p className="text">정보 입력</p>
-            </Step>
-          </StepContainer>
-        </TopContainer>
-        <MiddleContainer>
-          <div className="title">
-            <Title fontSize="22px" fontWeight="400">
-              기본정보
+      {showAlert ? <Alert text={alertMessage} onClickOk={isOk ? okGotoLogin : () => setShowAlert(false)} /> : null}
+      {type ? (
+        <InputContainer>
+          <TopContainer>
+            <Title fontSize="28px" fontWeight="500">
+              회원가입
             </Title>
-          </div>
-          <InfoTable>
-            <SingleInfo>
-              <div className="name email">이메일</div>
-              <div className="code-pos">
-                <ButtonDark
-                  width="60px"
-                  height="30px"
-                  fontSize="12px"
-                  fontWeight="500"
-                  borderRadious="30px"
-                  onClick={getCode}
-                >
-                  인증요청
-                </ButtonDark>
-              </div>
-              <div className="input-container">
-                <input onChange={onEmail} />
-                <div className="code">
-                  <p>인증코드</p>
-                  <input onChange={onCode} className="code-input" />
+            <StepContainer>
+              <Step type="off">
+                01<p className="text">약관동의</p>
+              </Step>
+              <MdOutlineKeyboardArrowRight size="22px" color="#A84448" />
+              <Step type="on">
+                02<p className="text">정보 입력</p>
+              </Step>
+            </StepContainer>
+          </TopContainer>
+          <MiddleContainer>
+            <div className="title">
+              <Title fontSize="22px" fontWeight="400">
+                기본정보
+              </Title>
+            </div>
+            <InfoTable>
+              {type === "oauth" ? null : (
+                <>
+                  <SingleInfo>
+                    <div className="name email">이메일</div>
+                    <div className="code-pos">
+                      <ButtonDark
+                        width="60px"
+                        height="30px"
+                        fontSize="12px"
+                        fontWeight="500"
+                        borderRadious="30px"
+                        onClick={getCode}
+                      >
+                        인증요청
+                      </ButtonDark>
+                    </div>
+                    <div className="input-container">
+                      <input onChange={onEmail} />
+                      <div className="code">
+                        <p>인증코드</p>
+                        <input onChange={onCode} className="code-input" />
+                      </div>
+                    </div>
+                  </SingleInfo>
+                  <SingleInfo>
+                    <div className="name">비밀번호</div>
+                    <div className="input-container">
+                      <input type="password" placeholder="문자, 숫자를 결합해 8자 이상" onChange={onPassword} />
+                    </div>
+                  </SingleInfo>
+                  <SingleInfo>
+                    <div className="name">비밀번호 확인</div>
+                    <div className="input-container">
+                      <input
+                        className={isDisabled ? "disable" : ""}
+                        type="password"
+                        placeholder={isDisabled ? "비밀번호를 먼저 옳바르게 입력하세요" : ""}
+                        disabled={isDisabled}
+                        onChange={onPasswordCheck}
+                      />
+                    </div>
+                  </SingleInfo>
+                </>
+              )}
+
+              <SingleInfo>
+                <div className="name">이름</div>
+                <div className="input-container">
+                  <input onChange={onName} />
                 </div>
-              </div>
-            </SingleInfo>
-            <SingleInfo>
-              <div className="name">비밀번호</div>
-              <div className="input-container">
-                <input type="password" placeholder="문자, 숫자를 결합해 8자 이상" onChange={onPassword} />
-              </div>
-            </SingleInfo>
-            <SingleInfo>
-              <div className="name">비밀번호 확인</div>
-              <div className="input-container">
-                <input
-                  className={isDisabled ? "disable" : ""}
-                  type="password"
-                  placeholder={isDisabled ? "비밀번호를 먼저 옳바르게 입력하세요" : ""}
-                  disabled={isDisabled}
-                  onChange={onPasswordCheck}
-                />
-              </div>
-            </SingleInfo>
-            <SingleInfo>
-              <div className="name">이름</div>
-              <div className="input-container">
-                <input onChange={onName} />
-              </div>
-            </SingleInfo>
-            <SingleInfo>
-              <div className="name">닉네임</div>
-              <div className="input-container">
-                <input onChange={onNick} />
-              </div>
-            </SingleInfo>
-            <SingleInfo>
-              <div className="name">생년월일</div>
-              <div className="input-container">
-                <input value={birth} type="date" onChange={onBirth} />
-              </div>
-            </SingleInfo>
-            <SingleInfo>
-              <div className="name">전화번호</div>
-              <div className="input-container">
-                <input value={number} onChange={onNumber} />
-              </div>
-            </SingleInfo>
-          </InfoTable>
-        </MiddleContainer>
-        <BottomContainer>
-          <ButtonLight
-            width="150px"
-            height="45px"
-            fontSize="18px"
-            borderRadious="2px"
-            onClick={() => navigate("/signup/term")}
-          >
-            이전
-          </ButtonLight>
-          <ButtonDark width="150px" height="45px" fontSize="18px" borderRadious="2px" onClick={onClickSign}>
-            회원가입
-          </ButtonDark>
-        </BottomContainer>
-      </InputContainer>
+              </SingleInfo>
+              <SingleInfo>
+                <div className="name">닉네임</div>
+                <div className="input-container">
+                  <input onChange={onNick} />
+                </div>
+              </SingleInfo>
+              <SingleInfo>
+                <div className="name">생년월일</div>
+                <div className="input-container">
+                  <input value={birth} type="date" onChange={onBirth} />
+                </div>
+              </SingleInfo>
+              <SingleInfo>
+                <div className="name">전화번호</div>
+                <div className="input-container">
+                  <input value={number} onChange={onNumber} />
+                </div>
+              </SingleInfo>
+            </InfoTable>
+          </MiddleContainer>
+          <BottomContainer>
+            <ButtonLight
+              width="150px"
+              height="45px"
+              fontSize="18px"
+              borderRadious="2px"
+              onClick={() => navigate("/signup/term")}
+            >
+              이전
+            </ButtonLight>
+            <ButtonDark width="150px" height="45px" fontSize="18px" borderRadious="2px" onClick={onClickSign}>
+              회원가입
+            </ButtonDark>
+          </BottomContainer>
+        </InputContainer>
+      ) : null}
     </Container>
   );
 };

--- a/client/src/pages/Signup/SignupSelection.tsx
+++ b/client/src/pages/Signup/SignupSelection.tsx
@@ -2,6 +2,9 @@ import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { TiSocialFacebook } from "react-icons/ti";
 import { FcGoogle } from "react-icons/fc";
+
+const url = `${process.env.REACT_APP_API_URL}`;
+
 type TypeProps = {
   type: string;
 };
@@ -84,12 +87,20 @@ const SignupSelection = () => {
   const toSignTerm = () => {
     navigate("/signup/term");
   };
+  const googleOAuthHandler = () => {
+    //오어스 구글 인증링크 이동
+    window.location.assign(`${url}/oauth2/authorization/google`);
+  };
+  const facebookOAuthHandler = () => {
+    //오어스 페이스북 인증링크로 이동
+    // window.location.assign(`${url}/oauth2/authorization/facebook`);
+  };
   return (
     <Container>
       <SelectionContainer>
         <BasicSignupBox onClick={toSignTerm}>쇼핑몰 회원가입</BasicSignupBox>
         <Contour />
-        <OAuthSignUpBox onClick={toSignTerm} type="google">
+        <OAuthSignUpBox onClick={googleOAuthHandler} type="google">
           <OAuthIconContainer>
             <FcGoogle size="40" color="black" />
           </OAuthIconContainer>

--- a/client/src/pages/Signup/SignupTerm.tsx
+++ b/client/src/pages/Signup/SignupTerm.tsx
@@ -1,10 +1,11 @@
-import styled, { ThemeContext } from "styled-components";
+import styled from "styled-components";
 import { MdOutlineKeyboardArrowRight } from "react-icons/md";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ButtonDark, ButtonLight } from "../../components/Common/Button";
-import { useContext } from "react";
+import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import Alert from "../../components/Common/AlertModal";
+
 // 05110209
 type StepProps = {
   type: string;
@@ -115,8 +116,6 @@ const SignupTerm = () => {
   const [detail, setDetail] = useState([false, false, false]);
   const [isNext, setIsNext] = useState(false);
   const [isAgreed, setIsAgreed] = useState([false, false, false, false]);
-
-  const themeContext = useContext(ThemeContext).colors;
   const detailData = [
     `[서비스 이용약관 동의서]
 
@@ -227,6 +226,35 @@ const SignupTerm = () => {
 1.서비스 이용에 대한 수수료는 회사가 별도로 정한 바에 따릅니다.
 `,
   ];
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const accessToken = urlParams.get("access_token");
+    const refreshToken = urlParams.get("refresh_token");
+    if (accessToken && refreshToken) {
+      localStorage.setItem("authToken", accessToken); // 토큰 저장
+      localStorage.setItem("refresh", refreshToken); // refresh 토큰 저장
+
+      axios
+        .get(`${process.env.REACT_APP_API_URL}/members`, {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: localStorage.getItem("authToken"),
+            "ngrok-skip-browser-warning": "69420",
+          },
+        })
+        .then((res) => {
+          navigate("/");
+          console.log("유저임");
+        })
+        .catch((err) => {
+          console.log("유저아님");
+          localStorage.setItem("oauthSign", "true"); // 오어스로 회원가입 시도
+        });
+    } else {
+      localStorage.setItem("oauthSign", "false"); // 일반 회원가입 시도
+    }
+  }, []);
   const clickDetail = (pos: number) => {
     const newDetail = detail.slice();
     newDetail[pos] = !detail[pos];
@@ -238,7 +266,6 @@ const SignupTerm = () => {
     setIsAgreed(newCheck);
   };
   const onClickNext = () => {
-    console.log(isAgreed);
     if (isAgreed[0] && isAgreed[1] && isAgreed[2] && isAgreed[3]) {
       navigate("/signup/input");
     } else {
@@ -247,7 +274,7 @@ const SignupTerm = () => {
   };
   return (
     <Container>
-      {isNext ? <Alert text="모든 약관을 동의해 주세요!" onClick={() => setIsNext(false)} /> : null}
+      {isNext ? <Alert text="모든 약관을 동의해 주세요!" onClickOk={() => setIsNext(false)} /> : null}
       <TermContainer>
         <TopContainer>
           <Title fontSize="28px" fontWeight="500">

--- a/client/src/types/Interfaces.ts
+++ b/client/src/types/Interfaces.ts
@@ -38,5 +38,6 @@ export interface Icon {
 
 export interface AlertProps {
   text: string;
-  onClick: () => void;
+  onClickOk: () => void;
+  onClickCancel?: () => void;
 }


### PR DESCRIPTION
### Branch
`fe-feat/주류리스트/#123` -> `fe`

### 변경 사항
-  Oauth 인증이후 url 파싱을 통해 토큰 저장
- 사용자의 Oauth 회원가입 시도 여부에 따라 다른 회원가입 폼 제공
- 오어스 회원가입자의 경우 별도의 수정페이지 폼 제공
- 기타 url 수정

### 유의사항
- Oauth 회원가입과 로그인 처리의 경우 로직이 아직 보완할 부분이 많이 있음